### PR TITLE
Fix crashes on empty files

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -295,6 +295,8 @@ var methods = {
 
   deleteLines: function (line, lines) {
     this.lines.splice(line, lines)
+    if (!lines.length)
+      this.lines.push('\n')
     while (lines)
       this.emit('delete_line', '', 1, line + (lines --))
     return this

--- a/plugins/basics.js
+++ b/plugins/basics.js
@@ -31,7 +31,7 @@ module.exports = function (doc, _, cursor) {
     }
     doc.lines = toLines(fs.readFileSync(file, 'utf-8'))
     var last = doc.lines.pop()
-    if(last != '\n')
+    if(last != '\n' || !doc.lines.length)
       doc.lines.push(last)
   } catch (_) { }
 


### PR DESCRIPTION
Fix #8.

This patch makes it so that there is always at least one (current) line available in the buffer and the editor won't crash.